### PR TITLE
Correct the word ConcurrenctQueue

### DIFF
--- a/backend/dotnet/questions/async-concurrency-threading.md
+++ b/backend/dotnet/questions/async-concurrency-threading.md
@@ -3,7 +3,7 @@
 * Concurrency vs Multi-Threading vs Async vs Parallelism
 * Data-Structures
 	* ConcurrentDictionary
-	* ConcurrenctQueue
+	* ConcurrentQueue
 	* Channels
 * Async & Task Internals
 	* At least, how many threads are needed to run an async task?

--- a/backend/dotnet/questions/ddd.md
+++ b/backend/dotnet/questions/ddd.md
@@ -30,7 +30,7 @@
 			* Anticorruption-Layer
 			* Shared-Kernel
 			* Customer/Supplier
-			* Patnership
+			* Partnership
 			* Published Language
 			* Separate Ways
 		* What's Upstream and Downstream?


### PR DESCRIPTION
I was checking the questions and came across the misspelling of the word Concurrenct. Did you mean Concurrent?

https://docs.microsoft.com/en-us/dotnet/api/system.collections.concurrent.concurrentqueue-1?view=net-6.0